### PR TITLE
add github action to run build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   RECIPE_ENGINE: ${{ secrets.RECIPE_ENGINE }}
-  INPUT_VERSION: ${{ insputs.input_version }}
+  INPUT_VERSION: ${{ inputs.input_version }}
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-outputs
-          path: data/${{ env.INPUT_VERSION }}/*
+          path: output/${{ env.INPUT_VERSION }}/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Archive outputs
         uses: actions/upload-artifact@v3
         with:
-          name: build-outputs
+          name: aue_outputs_${{ env.INPUT_VERSION }}
           path: output/${{ env.INPUT_VERSION }}/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-outputs
-          path: data/${INPUT_VERSION}/*
+          path: data/${{ env.INPUT_VERSION }}/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-outputs
-          path: data/$INPUT_VERSION/*
+          path: data/${INPUT_VERSION}/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  workflow_dispatch:
+    input_version:
+      description: Input dataset version (e.g. "latest")
+      type: string
+      required: true
+  workflow_call:
+    inputs:
+      input_version:
+        type: string
+        required: true
+
+env:
+  RECIPE_ENGINE: ${{ secrets.RECIPE_ENGINE }}
+  INPUT_VERSION: ${{ insputs.input_version }}
+
+jobs:
+  build:
+    name: Build Dataset
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup build environment
+        run: |
+          ./bash/setup_build_env.sh
+
+      - name: Run build
+        run: |
+          ./bash/aue.sh
+
+      - name: Archive outputs
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-outputs
+          path: data/$INPUT_VERSION/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build
+run-name: Build (version ${{ inputs.dataset }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    name: Build Dataset
+    name: Build dataset
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-run-name: Build (version ${{ inputs.dataset }})
+run-name: Build (version ${{ inputs.input_version }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: Tests (${{ github.ref_name }})
+run-name: Tests (${{ github.sha }})
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: "Tests (sha $GITHUB_SHA or $GITHUB_REF_NAME)"
+run-name: Tests (${{ github.ref_name }})
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: Tests (${{ github.ref_name }})
+run-name: Tests (${{ github.ref }})
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: Tests (sha $GITHUB_SHA)
+run-name: Tests (sha ${{ env.GITHUB_SHA }})
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: Tests
+
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  branch_build_tests:
+    name: Build test run
+    uses: ./.github/workflows/build.yml
+    with:
+      input: test
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: Tests (sha ${{ env.GITHUB_SHA }})
+run-name: "Tests (sha $GITHUB_SHA or $GITHUB_REF_NAME)"
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,5 +11,5 @@ jobs:
     name: Build test run
     uses: ./.github/workflows/build.yml
     with:
-      input: test
+      input_version: test
     secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: Tests (${{ github.sha }})
+run-name: Tests (${{ github.ref_name }})
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-run-name: Tests (${{ github.ref }})
+run-name: Tests (${{ github.event_name }})
 
 on: [pull_request, workflow_dispatch]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   branch_build_tests:
-    name: Build test run
+    name: Test build
     uses: ./.github/workflows/build.yml
     with:
       input_version: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,5 @@
 name: Tests
+run-name: Tests (sha $GITHUB_SHA)
 
 on: [pull_request, workflow_dispatch]
 


### PR DESCRIPTION
## changes
- add a github action to run the build process
  - outputs are available as a zip file in the action run ([example using test data](https://github.com/NYCPlanning/aue/actions/runs/4840595382))
  - the action is either run manually in github or called by another action
- add a github action to run tests
  - currently the only test is to run the build action with test data (via `INPUT_VERSION=test`)
  - the action is either  run manually or automatically on PRs